### PR TITLE
Super Silly Fix

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -121,7 +121,7 @@ permissions:
   essentialsnk.warp.others:
     default: op
   essentialsnk.world:
-    default: true
+    default: op
   essentialsnk.reload:
     default: op
   essentialsnk.whois:


### PR DESCRIPTION
In no ones right mind should default players be able to transfer to worlds that there is no warp set for, in my case I did not set the warp in that world for a reason lmao. Regardless this is fixed